### PR TITLE
Remove redundent list

### DIFF
--- a/Bored/Bored.py
+++ b/Bored/Bored.py
@@ -1,7 +1,7 @@
 # Console program that will return from a list; a random chore, a random fun thing to do, or a 
 # random selection from a list of both chores and fun things to do.
 #
-# V: 0.1.1
+# V: 0.2.0
 
 import sys
 import random

--- a/Bored/Bored.py
+++ b/Bored/Bored.py
@@ -78,6 +78,7 @@ def generateActivity() :
 
         try :
            allList = readFile('all')
+           print(allList) # Testing
            displayOutput(random.choice(allList))
 
            # TODO enhancement = derive all list from combing chore.txt and fun.txt
@@ -92,6 +93,8 @@ def generateActivity() :
             print('Using default all activities list...\n')
             displayOutput(random.choice(allActivities))
 
+            #print(allList) # Testing
+            print(type(allList)) # Testing
             var = traceback.format_exc() # Testing
             print(var) # Testing
 
@@ -100,6 +103,7 @@ def generateActivity() :
         try :
             choreList = readFile('chore')
             displayOutput(random.choice(choreList))
+            print(choreList) # Testing
 
         except FileNotFoundError :
             print('Sorry, chore activities list, file not found ')
@@ -115,6 +119,7 @@ def generateActivity() :
         try :
             funList = readFile('fun')
             displayOutput(random.choice(funList))
+            print(funList) # Testing
 
         except FileNotFound :
             print('Sorry, fun activities, list, file not found')

--- a/Bored/Bored.py
+++ b/Bored/Bored.py
@@ -6,7 +6,7 @@
 import sys
 import random
 #import os # Used in testing 
-import traceback # Used in testing 
+#import traceback # Used in testing 
 
 def menu():
 
@@ -53,7 +53,9 @@ def readFile(list) :
             dictionary_chore = c.readlines() 
 
             choreList = [word.strip() for word in dictionary_chore] 
-        ActivityList = funList.extend(choreList)
+
+        ActivityList = funList
+        ActivityList.extend(choreList)
 
     else :
 
@@ -64,6 +66,7 @@ def readFile(list) :
         # Seperates each word to create a list of words
         ActivityList = [word.strip() for word in dictionary] 
      
+    #print(ActivityList) # Testing
     return(ActivityList) 
 
 
@@ -78,10 +81,8 @@ def generateActivity() :
 
         try :
            allList = readFile('all')
-           print(allList) # Testing
+           #print(allList) # Testing
            displayOutput(random.choice(allList))
-
-           # TODO enhancement = derive all list from combing chore.txt and fun.txt
 
         except FileNotFoundError :
             print('Sorry, all activities list, file not found')
@@ -94,16 +95,16 @@ def generateActivity() :
             displayOutput(random.choice(allActivities))
 
             #print(allList) # Testing
-            print(type(allList)) # Testing
-            var = traceback.format_exc() # Testing
-            print(var) # Testing
+            #print(type(allList)) # Testing
+            #var = traceback.format_exc() # Testing
+            #print(var) # Testing
 
     elif menu() == 'C' :
 
         try :
             choreList = readFile('chore')
             displayOutput(random.choice(choreList))
-            print(choreList) # Testing
+            #print(choreList) # Testing
 
         except FileNotFoundError :
             print('Sorry, chore activities list, file not found ')
@@ -119,7 +120,7 @@ def generateActivity() :
         try :
             funList = readFile('fun')
             displayOutput(random.choice(funList))
-            print(funList) # Testing
+            #print(funList) # Testing
 
         except FileNotFound :
             print('Sorry, fun activities, list, file not found')

--- a/Bored/Bored.py
+++ b/Bored/Bored.py
@@ -6,7 +6,7 @@
 import sys
 import random
 #import os # Used in testing 
-#import traceback # Used in testing 
+import traceback # Used in testing 
 
 def menu():
 
@@ -40,12 +40,29 @@ def readFile(list) :
     READ = 'r'
     fileName = list + '.txt'
 
-    with open(fileName, READ) as f :
-        # Reads the entire file
-        dictionary = f.readlines() 
+    if list == 'all' : 
 
-    # Seperates each word to create a list of words
-    ActivityList = [word.strip() for word in dictionary] 
+        with open('fun.txt', READ) as f :
+            # Reads the entire file
+            dictionary_fun = f.readlines() 
+
+            funList = [word.strip() for word in dictionary_fun]
+
+        with open('chore.txt', READ) as c :
+            # Reads the entire file
+            dictionary_chore = c.readlines() 
+
+            choreList = [word.strip() for word in dictionary_chore] 
+        ActivityList = funList.extend(choreList)
+
+    else :
+
+        with open(fileName, READ) as f :
+            # Reads the entire file
+            dictionary = f.readlines() 
+
+        # Seperates each word to create a list of words
+        ActivityList = [word.strip() for word in dictionary] 
      
     return(ActivityList) 
 
@@ -75,8 +92,8 @@ def generateActivity() :
             print('Using default all activities list...\n')
             displayOutput(random.choice(allActivities))
 
-            #var = traceback.format_exc() # Testing
-            #print(var) # Testing
+            var = traceback.format_exc() # Testing
+            print(var) # Testing
 
     elif menu() == 'C' :
 


### PR DESCRIPTION
Fixes the error in #5 which was caused by an incorrect use of .extend(), which returned none where a list was required.